### PR TITLE
Bug 1066722 - Support double click for moving an item from a list to the other in the exceptions page

### DIFF
--- a/ui/partials/main/thMultiSelect.html
+++ b/ui/partials/main/thMultiSelect.html
@@ -6,7 +6,7 @@
 
   <div class="form-group-inline">
     <div class="form-group-side form-control">
-      <reactselect list="leftList" side="'left'" filter="query" watch-depth="collection"></reactselect>
+      <reactselect list="leftList" side="'left'" filter="query" watch-depth="collection" ng-dblclick="move_right()"></reactselect>
     </div>
 
     <div class="btn-group-vertical btn-move">
@@ -22,7 +22,7 @@
     </div>
 
     <div class="form-group-side form-control">
-      <reactselect list="rightList" side="'right'" filter="query" watch-depth="collection"></reactselect>
+      <reactselect list="rightList" side="'right'" filter="query" watch-depth="collection" ng-dblclick="move_left()"></reactselect>
     </div>
   </div>
 </div>


### PR DESCRIPTION
In the exceptions page of the admin section, the items can now be moved from the left list to the right list (or from included and excluded) by double clicking on them.

Refers to: https://bugzilla.mozilla.org/show_bug.cgi?id=1066722
